### PR TITLE
Add support for comments in mustfiles

### DIFF
--- a/src/mustfile.pest
+++ b/src/mustfile.pest
@@ -1,7 +1,8 @@
-must = _{ SOI ~ "\n"* ~ (task ~ "\n"+)* ~ task? ~ EOI }
-task = { target ~ ":" ~ dependent* ~ ("\n" ~ steps)? }
+must = _{ SOI ~ "\n"* ~ (comment ~ "\n"+)* ~ (task ~ "\n"+ ~ (comment ~ "\n"+)*)* ~ task? ~ EOI }
+task = { target ~ ":" ~ dependent* ~ comment? ~ ("\n" ~ steps)? }
 steps = _{ step ~ (NEWLINE ~ step)* }
-step = _{ ("\t" | " ")+ ~ action }
-dependent = { " " ~ target }
-action = { (ASCII_ALPHANUMERIC | "'" | "\"" | "-" | " " | ".")+ }
+step = _{ ("\t" | " ")+ ~ action ~ comment? }
+dependent = { " " ~ target ~ comment? }
+action = { (!("#" | NEWLINE) ~ ANY)+ }
 target = { (ASCII_ALPHANUMERIC | "/" | "_" | "-")+ }
+comment = _{ " "? ~ "#" ~ (!NEWLINE ~ ANY)* }

--- a/tests/fixtures/comments.must
+++ b/tests/fixtures/comments.must
@@ -1,0 +1,10 @@
+# This is a top-level comment
+
+target1: dep1 # This is a dependency comment
+    echo "hello world" # This is a step comment
+    echo hello world # Another step comment
+
+# Another top-level comment
+target2: # Comment after colon
+    echo "test" # Comment with quotes
+    echo test # Comment without quotes


### PR DESCRIPTION
This PR adds support for comments in mustfiles. Changes: Updated grammar to support comments in various locations, added test fixtures and test cases. Closes #9